### PR TITLE
Add React portfolio scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# front-endtest
+# Front-end Portfolio
+
+Deze repository bevat een eenvoudige single-page React applicatie die dient als portfolio. De applicatie is gebouwd met React, Vite en Tailwind CSS. Animaties worden verzorgd door Framer Motion.
+
+## Installatie
+
+1. Installeer dependencies:
+   ```bash
+   npm install
+   ```
+2. Start de ontwikkelserver:
+   ```bash
+   npm start
+   ```
+
+De applicatie is nu bereikbaar op `http://localhost:5173` (standaard Vite-poort).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "vite",
+    "build": "vite build",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "framer-motion": "^10.12.16",
+    "react-icons": "^4.11.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14",
+    "vite": "^4.1.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Hero from './components/Hero';
+import About from './components/About';
+import Portfolio from './components/Portfolio';
+import ContactForm from './components/ContactForm';
+
+export default function App() {
+  return (
+    <div>
+      <Hero />
+      <About />
+      <Portfolio />
+      <ContactForm />
+    </div>
+  );
+}

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { FaGithub, FaLinkedin } from 'react-icons/fa';
+
+export default function About() {
+  return (
+    <section id="about" className="py-16 bg-neutralLight text-neutralDark">
+      <div className="container mx-auto px-4 flex flex-col md:flex-row items-center">
+        <div className="w-32 h-32 bg-neutralDark rounded-full mx-auto md:mx-0 mb-6 md:mb-0" />
+        <div className="md:ml-8">
+          <h2 className="text-3xl font-bold mb-4">Over mij</h2>
+          <ul className="list-disc pl-5 space-y-2 mb-4">
+            <li>HTML5</li>
+            <li>CSS3</li>
+            <li>JavaScript</li>
+            <li>React</li>
+            <li>Tailwind</li>
+          </ul>
+          <div className="flex space-x-4">
+            <a href="#" aria-label="LinkedIn" className="text-2xl hover:text-accent"><FaLinkedin /></a>
+            <a href="#" aria-label="GitHub" className="text-2xl hover:text-accent"><FaGithub /></a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+export default function ContactForm() {
+  const [form, setForm] = useState({ name: '', email: '', message: '' });
+  const [errors, setErrors] = useState({});
+
+  const handleChange = e => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const validate = () => {
+    const errs = {};
+    if (!form.name) errs.name = 'Naam is verplicht';
+    if (!form.email) {
+      errs.email = 'E-mail is verplicht';
+    } else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(form.email)) {
+      errs.email = 'Ongeldig e-mail formaat';
+    }
+    if (!form.message) errs.message = 'Bericht is verplicht';
+    setErrors(errs);
+    return Object.keys(errs).length === 0;
+  };
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    if (validate()) {
+      console.log(form);
+      alert('Bericht verzonden (mock)');
+      setForm({ name: '', email: '', message: '' });
+    }
+  };
+
+  return (
+    <section id="contact" className="py-16 bg-neutralLight">
+      <div className="container mx-auto px-4 max-w-lg">
+        <h2 className="text-3xl font-bold text-center mb-8">Contact</h2>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <input name="name" value={form.name} onChange={handleChange} placeholder="Naam" className="w-full p-2 border rounded-lg" />
+            {errors.name && <p className="text-sm text-accent">{errors.name}</p>}
+          </div>
+          <div>
+            <input name="email" value={form.email} onChange={handleChange} placeholder="E-mail" className="w-full p-2 border rounded-lg" />
+            {errors.email && <p className="text-sm text-accent">{errors.email}</p>}
+          </div>
+          <div>
+            <textarea name="message" value={form.message} onChange={handleChange} placeholder="Bericht" className="w-full p-2 border rounded-lg" rows="4" />
+            {errors.message && <p className="text-sm text-accent">{errors.message}</p>}
+          </div>
+          <button className="bg-primary text-white font-semibold py-2 px-4 rounded-lg hover:bg-secondary transition">
+            Verzend
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function Hero() {
+  const scrollToPortfolio = () => {
+    document.getElementById('portfolio').scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <section className="h-screen flex flex-col justify-center items-center text-center bg-gradient-to-r from-primary to-secondary text-white">
+      <motion.h1 className="text-5xl font-bold mb-4" initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+        Jouw Naam
+      </motion.h1>
+      <p className="text-xl mb-8">Creative Front-end Developer</p>
+      <button onClick={scrollToPortfolio} className="bg-accent hover:bg-secondary text-white font-semibold py-2 px-4 rounded-lg shadow transition">
+        Bekijk mijn werk
+      </button>
+    </section>
+  );
+}

--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+export default function Modal({ children, onClose }) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50" onClick={onClose}>
+      <motion.div
+        onClick={e => e.stopPropagation()}
+        initial={{ opacity: 0, scale: 0.9 }}
+        animate={{ opacity: 1, scale: 1 }}
+        className="bg-white p-6 rounded-lg shadow-lg max-w-lg w-full"
+      >
+        {children}
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ProjectCard from './ProjectCard';
+
+const projects = [
+  { id: 1, title: 'Project 1', image: 'https://via.placeholder.com/400x300', description: 'Beschrijving van project 1', demo: '#', code: '#' },
+  { id: 2, title: 'Project 2', image: 'https://via.placeholder.com/400x300', description: 'Beschrijving van project 2', demo: '#', code: '#' },
+  { id: 3, title: 'Project 3', image: 'https://via.placeholder.com/400x300', description: 'Beschrijving van project 3', demo: '#', code: '#' },
+];
+
+export default function Portfolio() {
+  return (
+    <section id="portfolio" className="py-16 container mx-auto px-4">
+      <h2 className="text-3xl font-bold text-center mb-8">Portfolio</h2>
+      <div className="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3">
+        {projects.map(project => (
+          <ProjectCard key={project.id} project={project} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectCard.jsx
+++ b/src/components/ProjectCard.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import Modal from './Modal';
+
+export default function ProjectCard({ project }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div onClick={() => setOpen(true)} className="cursor-pointer overflow-hidden rounded-lg shadow-lg hover:shadow-2xl transform hover:scale-105 transition">
+        <img src={project.image} alt={project.title} className="w-full h-48 object-cover" />
+        <div className="p-4 bg-neutralLight">
+          <h3 className="font-semibold">{project.title}</h3>
+        </div>
+      </div>
+      {open && (
+        <Modal onClose={() => setOpen(false)}>
+          <h3 className="text-xl font-bold mb-2">{project.title}</h3>
+          <p className="mb-4">{project.description}</p>
+          <div className="flex space-x-4">
+            <a href={project.demo} className="text-secondary hover:text-accent">Live Demo</a>
+            <a href={project.code} className="text-secondary hover:text-accent">Code</a>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-inter bg-neutralLight text-neutralDark;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: '#0052CC',
+        secondary: '#2684FF',
+        accent: '#FF5630',
+        neutralDark: '#253858',
+        neutralLight: '#F4F5F7',
+      },
+      fontFamily: {
+        inter: ['Inter', 'sans-serif'],
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- scaffold a simple React portfolio with Vite and Tailwind CSS
- add hero, about, portfolio, project modal and contact components
- provide Tailwind config with custom colors
- document install/start steps in README

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684b45d177a48325b31ea70c91bce11c